### PR TITLE
Fixed null pointer

### DIFF
--- a/src/main/java/frc/robot/subsystems/EndE.java
+++ b/src/main/java/frc/robot/subsystems/EndE.java
@@ -22,7 +22,6 @@ import frc.robot.Robot;
 
 public class EndE extends SubsystemBase {
     private LaserCan lc = new LaserCan(29);
-    LaserCan.Measurement measurement = lc.getMeasurement();
     // intake setup
     private SparkFlex intakeMotor = new SparkFlex(ArmConstants.IntakeCanID, MotorType.kBrushless);
     private boolean CoralEngaged = false;
@@ -35,7 +34,10 @@ public class EndE extends SubsystemBase {
     }
 
     public boolean isCoralEngaged() {
-        return lc.getMeasurement().distance_mm <= 30;
+        Measurement measurement = lc.getMeasurement();
+        return measurement != null
+                && measurement.status == LaserCan.LASERCAN_STATUS_VALID_MEASUREMENT
+                && measurement.distance_mm <= 30;
     }
 
     public void periodic() {


### PR DESCRIPTION
Fixing this error
"Error at frc.robot.subsystems.EndE.isCoralEngaged(EndE.java:38): Unhandled exception instantiating robot frc.robot.subsystems.EndE
  java.lang.NullPointerException: Cannot read field "distance_mm" because the return value of "au.grapplerobotics.LaserCan.getMeasurement()" is null
          at frc.robot.subsystems.EndE.isCoralEngaged(EndE.java:38)
          at frc.robot.Robot.<init>(Robot.java:34)
          at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:370)
          at edu.wpi.first.wpilibj.RobotBase.startRobot(RobotBase.java:510)
          at frc.robot.Main.main(Main.java:23)"