### PR TITLE
Triggering end condition sooner

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -228,6 +228,11 @@ public final class Constants {
                                                                                   // speed to PID control
   public static final double AUTO_ALIGNMENT_FAST_APPROACH_SPEED = 1.2; // Fast approach speed in m/s when far from the
                                                                        // reef
+  public static final double AUTO_ALIGNMENT_LINEAR_SETTLE_SPEED = 0.12; // Robot linear speed considered "settled"
+  public static final double AUTO_ALIGNMENT_ANGULAR_SETTLE_SPEED = 0.6; // Robot angular speed considered "settled"
+  public static final double AUTO_ALIGNMENT_X_CLOSE_ENOUGH = 0.12; // Allowable X error to finish auto align early
+  public static final double AUTO_ALIGNMENT_Y_CLOSE_ENOUGH = 0.18; // Allowable Y error to finish auto align early
+  public static final double AUTO_ALIGNMENT_ROT_CLOSE_ENOUGH = 1; // Allowable rotation error (degrees) for completion
 
   // Shift these setpoints when the robot stops short, crashes the reef, or parks
   // off-center.

--- a/src/main/java/frc/robot/commands/AutonLAlignToReefTagRelative.java
+++ b/src/main/java/frc/robot/commands/AutonLAlignToReefTagRelative.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.controller.HolonomicDriveController;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
@@ -105,6 +106,7 @@ public class AutonLAlignToReefTagRelative extends Command {
 
     // Latch the first tag we see so the robot does not jump between IDs mid-align.
     tagID = LimelightHelpers.getFiducialID("limelight-right");
+    LatPose = false;
   }
 
   @Override
@@ -154,9 +156,29 @@ public class AutonLAlignToReefTagRelative extends Command {
       }
 
       double ySpeed = yController.calculate(postions[0]);
+      double yError = yController.getPositionError();
       double rotValue = rotController.calculate(postions[4]);
+      double xError = xController.getPositionError();
+      double rotError = rotController.getPositionError();
 
-      boolean atPose = rotController.atSetpoint() && yController.atSetpoint() && xController.atSetpoint();
+      double xClose = Constants.AUTO_ALIGNMENT_X_CLOSE_ENOUGH;
+      double yClose = Constants.AUTO_ALIGNMENT_Y_CLOSE_ENOUGH;
+      double rotClose = Constants.AUTO_ALIGNMENT_ROT_CLOSE_ENOUGH;
+      if (Math.abs(xError) < 0.15 && Math.abs(yError) < 0.2) {
+        xClose = Constants.X_TOLERANCE_REEF_ALIGNMENT;
+        yClose = Constants.Y_TOLERANCE_REEF_ALIGNMENT;
+        rotClose = Constants.ROT_TOLERANCE_REEF_ALIGNMENT;
+      }
+      boolean withinTolerances = Math.abs(xError) < xClose
+          && Math.abs(yError) < yClose
+          && Math.abs(rotError) < rotClose;
+      ChassisSpeeds robotSpeeds = drivebase.getRobotRelativeSpeeds();
+      boolean translationSettled = Math.hypot(robotSpeeds.vxMetersPerSecond,
+          robotSpeeds.vyMetersPerSecond) < Constants.AUTO_ALIGNMENT_LINEAR_SETTLE_SPEED;
+      boolean rotationSettled = Math
+          .abs(robotSpeeds.omegaRadiansPerSecond) < Constants.AUTO_ALIGNMENT_ANGULAR_SETTLE_SPEED;
+      boolean atPose = withinTolerances && translationSettled && rotationSettled;
+
       if (atPose) {
         drivebase.stop();
         if (stopTimer.hasElapsed(Constants.POSE_VALIDATION_TIME)) {
@@ -170,8 +192,9 @@ public class AutonLAlignToReefTagRelative extends Command {
           }
         }
       } else {
-        stopTimer.reset();
+        stopTimer.restart();
         lastPoseValidatedTimestamp = -1;
+        LatPose = false;
         drivebase.drive(
             new Translation2d(
                 // If we jump forward before we are centered, increase the Y tolerance gate or

--- a/src/main/java/frc/robot/commands/AutonRAlignToReefTagRelative.java
+++ b/src/main/java/frc/robot/commands/AutonRAlignToReefTagRelative.java
@@ -8,6 +8,7 @@ import edu.wpi.first.math.controller.HolonomicDriveController;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
@@ -100,6 +101,7 @@ public class AutonRAlignToReefTagRelative extends Command {
 
     // Remember which tag we locked on so we stay tied to the correct reef face.
     tagID = LimelightHelpers.getFiducialID("limelight-left");
+    RatPose = false;
   }
 
   @Override
@@ -121,9 +123,29 @@ public class AutonRAlignToReefTagRelative extends Command {
       }
 
       double ySpeed = yController.calculate(postions[0]);
+      double yError = yController.getPositionError();
       double rotValue = rotController.calculate(postions[4]);
+      double xError = xController.getPositionError();
+      double rotError = rotController.getPositionError();
 
-      boolean atPose = rotController.atSetpoint() && yController.atSetpoint() && xController.atSetpoint();
+      double xClose = Constants.AUTO_ALIGNMENT_X_CLOSE_ENOUGH;
+      double yClose = Constants.AUTO_ALIGNMENT_Y_CLOSE_ENOUGH;
+      double rotClose = Constants.AUTO_ALIGNMENT_ROT_CLOSE_ENOUGH;
+      if (Math.abs(xError) < 0.15 && Math.abs(yError) < 0.2) {
+        xClose = Constants.X_TOLERANCE_REEF_ALIGNMENT;
+        yClose = Constants.Y_TOLERANCE_REEF_ALIGNMENT;
+        rotClose = Constants.ROT_TOLERANCE_REEF_ALIGNMENT;
+      }
+      boolean withinTolerances = Math.abs(xError) < xClose
+          && Math.abs(yError) < yClose
+          && Math.abs(rotError) < rotClose;
+      ChassisSpeeds robotSpeeds = drivebase.getRobotRelativeSpeeds();
+      boolean translationSettled = Math.hypot(robotSpeeds.vxMetersPerSecond,
+          robotSpeeds.vyMetersPerSecond) < Constants.AUTO_ALIGNMENT_LINEAR_SETTLE_SPEED;
+      boolean rotationSettled = Math
+          .abs(robotSpeeds.omegaRadiansPerSecond) < Constants.AUTO_ALIGNMENT_ANGULAR_SETTLE_SPEED;
+      boolean atPose = withinTolerances && translationSettled && rotationSettled;
+
       if (atPose) {
         drivebase.stop();
         if (stopTimer.hasElapsed(Constants.POSE_VALIDATION_TIME)) {
@@ -137,8 +159,9 @@ public class AutonRAlignToReefTagRelative extends Command {
           }
         }
       } else {
-        stopTimer.reset();
+        stopTimer.restart();
         lastPoseValidatedTimestamp = -1;
+        RatPose = false;
         // If the right-side approach veers left/right swap the sign of ySpeed or tune Y
         // setpoint/tolerance.
         drivebase.drive(

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -235,6 +235,10 @@ public class SwerveSubsystem extends SubsystemBase {
         swerveDrive.kinematics.toSwerveModuleStates(new ChassisSpeeds(0, 0, 0)), true);
   }
 
+  public ChassisSpeeds getRobotRelativeSpeeds() {
+    return swerveDrive.getRobotVelocity();
+  }
+
   public Command stopCommand() {
     return this.runOnce(() -> {
       stop();


### PR DESCRIPTION
                                                                                                                                    
  - Auto-alignment (left/right, auton) now checks controller errors directly and uses a two-stage tolerance: start with relaxed AUTO_ALIGNMENT_*_CLOSE_ENOUGH, then tighten back    to the original reef tolerances once the robot is nearly centered. We still demand low chassis speeds before finishing, so accuracy is preserved while shaving the final    
    1‑2 s wait.
  - Added new tuning knobs ( AUTO_ALIGNMENT_*_CLOSE_ENOUGH, settle-speed thresholds) to Constants so the release timing can be dialed in without    
    touching command code.
    
    
    These changes let auton align complete as soon as the chassis is effectively on target (and settled) instead of waiting for perfect PID convergence, which removes the        
  noticeable lag but keeps the final pose quality intact.